### PR TITLE
Update/cmake-build-refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(AGENTVIZ_FULL_DEBUG_SYMBOLS TRUE)
+#set(AGENTVIZ_FULL_DEBUG_SYMBOLS TRUE)
 
 if(NOT DEFINED DIMENSION)
     set(DIMENSION 3) # Used by Cytosim to compile 2D or 3D
@@ -18,75 +18,75 @@ link_directories(
 
 add_compile_options(-Wno-deprecated-declarations)
 
-if(${AGENTVIZ_FULL_DEBUG_SYMBOLS})
-  message("Building Agent Viz with full debugging symbols")
-  add_definitions("-g3 -ggdb")
-endif()
+#if(${AGENTVIZ_FULL_DEBUG_SYMBOLS})
+	#message("Building Agent Viz with full debugging symbols")
+	add_definitions("-g3 -ggdb")
+#endif()
 
 # The file extension to attach to executables built
-set(EXE_FILE_TYPE "exe")
+#set(EXE_FILE_TYPE "exe")
 
-set(SERVER_PROGRAM "${SERVER_TARGET}.${EXE_FILE_TYPE}")
-set(CLIENT_PROGRAM "${CLIENT_TARGET}.${EXE_FILE_TYPE}")
+#set(SERVER_PROGRAM "${SERVER_TARGET}.${EXE_FILE_TYPE}")
+#set(CLIENT_PROGRAM "${CLIENT_TARGET}.${EXE_FILE_TYPE}")
 
-set(SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/src")
-set(INCLUDE_DIRECTORY "${CMAKE_SOURCE_DIR}/inc")
-set(EXTERNAL_DIRECTORY "${CMAKE_SOURCE_DIR}/ext")
+#set(SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/src")
+#set(INCLUDE_DIRECTORY "${CMAKE_SOURCE_DIR}/inc")
+#set(EXTERNAL_DIRECTORY "${CMAKE_SOURCE_DIR}/ext")
 set(DEPENDENCY_DIRECTORY "${CMAKE_SOURCE_DIR}/dep")
 
-SET(CMAKE_EXE_LINKER_FLAGS
-"${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath /usr/local/lib -Wl,-rpath /usr/lib")
+#SET(CMAKE_EXE_LINKER_FLAGS
+#"${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath /usr/local/lib -Wl,-rpath /usr/lib")
 
-project(${TARGET})
-add_executable(${SERVER_PROGRAM} ${SOURCE_DIRECTORY}/${SERVER_TARGET}.cpp)
+#project(${TARGET})
+#add_executable(${SERVER_PROGRAM} ${SOURCE_DIRECTORY}/${SERVER_TARGET}.cpp)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-find_package(OpenSSL REQUIRED)
-find_package(HDF5 COMPONENTS HL REQUIRED)
+#set(THREADS_PREFER_PTHREAD_FLAG ON)
+#find_package(Threads REQUIRED)
+#find_package(OpenSSL REQUIRED)
+#find_package(HDF5 COMPONENTS HL REQUIRED)
 
-if(UNIX AND APPLE)
-  set(PLATFORM_LIBRARIES
-    "crypto"
-  )
-endif()
+#if(UNIX AND APPLE)
+#  set(PLATFORM_LIBRARIES
+#    "crypto"
+#  )
+#endif()
 
-target_include_directories(${SERVER_PROGRAM} PUBLIC
-"${INCLUDE_DIRECTORY}"
-"${EXTERNAL_DIRECTORY}"
-"${EXTERNAL_DIRECTORY}/websocketpp"
-"${EXTERNAL_DIRECTORY}/websocketpp/common"
-"${EXTERNAL_DIRECTORY}/asio"
-"/usr/local/opt/openssl/include"
-)
+#target_include_directories(${SERVER_PROGRAM} PUBLIC
+#"${INCLUDE_DIRECTORY}"
+#"${EXTERNAL_DIRECTORY}"
+#"${EXTERNAL_DIRECTORY}/websocketpp"
+#"${EXTERNAL_DIRECTORY}/websocketpp/common"
+#"${EXTERNAL_DIRECTORY}/asio"
+#"/usr/local/opt/openssl/include"
+#)
 
 add_subdirectory(${DEPENDENCY_DIRECTORY})
-add_subdirectory(${SOURCE_DIRECTORY})
+#add_subdirectory(${SOURCE_DIRECTORY})
 
-target_link_libraries(${SERVER_PROGRAM}
-    "${TARGET}"
-    Threads::Threads
-)
+#target_link_libraries(${SERVER_PROGRAM}
+#    "${TARGET}"
+#    Threads::Threads
+#)
 
-set(CLIENT_PROGRAM_SOURCES
-    "${SOURCE_DIRECTORY}/${CLIENT_TARGET}.cpp"
-    "${EXTERNAL_DIRECTORY}/json/jsoncpp.cpp"
-    "${SOURCE_DIRECTORY}/main/cli_client.cpp"
-)
-add_executable(${CLIENT_PROGRAM} ${CLIENT_PROGRAM_SOURCES})
-target_include_directories(${CLIENT_PROGRAM} PRIVATE
-    "${INCLUDE_DIRECTORY}"
-    "${EXTERNAL_DIRECTORY}"
-    "${EXTERNAL_DIRECTORY}/websocketpp"
-    "${EXTERNAL_DIRECTORY}/websocketpp/common"
-    "${EXTERNAL_DIRECTORY}/asio"
-    "${OPENSSL_INCLUDES}"
-    "/usr/local/opt/openssl/include"
-)
-target_link_libraries(${CLIENT_PROGRAM}
-    Threads::Threads
-    ${OPENSSL_LIBRARIES}
-    ${PLATFORM_LIBRARIES}
-)
+#set(CLIENT_PROGRAM_SOURCES
+#    "${SOURCE_DIRECTORY}/${CLIENT_TARGET}.cpp"
+#    "${EXTERNAL_DIRECTORY}/json/jsoncpp.cpp"
+#    "${SOURCE_DIRECTORY}/main/cli_client.cpp"
+#)
+#add_executable(${CLIENT_PROGRAM} ${CLIENT_PROGRAM_SOURCES})
+#target_include_directories(${CLIENT_PROGRAM} PRIVATE
+#    "${INCLUDE_DIRECTORY}"
+#    "${EXTERNAL_DIRECTORY}"
+#    "${EXTERNAL_DIRECTORY}/websocketpp"
+#    "${EXTERNAL_DIRECTORY}/websocketpp/common"
+#    "${EXTERNAL_DIRECTORY}/asio"
+#    "${OPENSSL_INCLUDES}"
+#    "/usr/local/opt/openssl/include"
+#)
+#target_link_libraries(${CLIENT_PROGRAM}
+#    Threads::Threads
+#    ${OPENSSL_LIBRARIES}
+#    ${PLATFORM_LIBRARIES}
+#)
 
-file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/trajectory")
+#file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/trajectory")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,91 +2,32 @@ cmake_minimum_required(VERSION 3.2.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-#set(AGENTVIZ_FULL_DEBUG_SYMBOLS TRUE)
-
-if(NOT DEFINED DIMENSION)
-    set(DIMENSION 3) # Used by Cytosim to compile 2D or 3D
-endif()
+set(DIMENSION 3) # Used by Cytosim to compile 2D or 3D
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 set(TARGET "agentsim")
 set(SERVER_TARGET "agentsim_server")
 set(CLIENT_TARGET "agentsim_client")
 
-link_directories(
-  "/usr/local/opt/openssl/lib"
-)
-
 add_compile_options(-Wno-deprecated-declarations)
 
-#if(${AGENTVIZ_FULL_DEBUG_SYMBOLS})
-	#message("Building Agent Viz with full debugging symbols")
-	add_definitions("-g3 -ggdb")
-#endif()
+message("Building Agent Viz with full debugging symbols")
+add_definitions("-g3 -ggdb")
 
 # The file extension to attach to executables built
-#set(EXE_FILE_TYPE "exe")
+set(EXE_FILE_TYPE "exe")
 
-#set(SERVER_PROGRAM "${SERVER_TARGET}.${EXE_FILE_TYPE}")
-#set(CLIENT_PROGRAM "${CLIENT_TARGET}.${EXE_FILE_TYPE}")
+set(SERVER_PROGRAM "${SERVER_TARGET}.${EXE_FILE_TYPE}")
+set(CLIENT_PROGRAM "${CLIENT_TARGET}.${EXE_FILE_TYPE}")
 
-#set(SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/src")
-#set(INCLUDE_DIRECTORY "${CMAKE_SOURCE_DIR}/inc")
-#set(EXTERNAL_DIRECTORY "${CMAKE_SOURCE_DIR}/ext")
+set(SOURCE_DIRECTORY "${CMAKE_SOURCE_DIR}/src")
+set(INCLUDE_DIRECTORY "${CMAKE_SOURCE_DIR}/inc")
+set(EXTERNAL_DIRECTORY "${CMAKE_SOURCE_DIR}/ext")
 set(DEPENDENCY_DIRECTORY "${CMAKE_SOURCE_DIR}/dep")
 
-#SET(CMAKE_EXE_LINKER_FLAGS
-#"${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath /usr/local/lib -Wl,-rpath /usr/lib")
-
-#project(${TARGET})
-#add_executable(${SERVER_PROGRAM} ${SOURCE_DIRECTORY}/${SERVER_TARGET}.cpp)
-
-#set(THREADS_PREFER_PTHREAD_FLAG ON)
-#find_package(Threads REQUIRED)
-#find_package(OpenSSL REQUIRED)
-#find_package(HDF5 COMPONENTS HL REQUIRED)
-
-#if(UNIX AND APPLE)
-#  set(PLATFORM_LIBRARIES
-#    "crypto"
-#  )
-#endif()
-
-#target_include_directories(${SERVER_PROGRAM} PUBLIC
-#"${INCLUDE_DIRECTORY}"
-#"${EXTERNAL_DIRECTORY}"
-#"${EXTERNAL_DIRECTORY}/websocketpp"
-#"${EXTERNAL_DIRECTORY}/websocketpp/common"
-#"${EXTERNAL_DIRECTORY}/asio"
-#"/usr/local/opt/openssl/include"
-#)
+project(${TARGET})
 
 add_subdirectory(${DEPENDENCY_DIRECTORY})
-#add_subdirectory(${SOURCE_DIRECTORY})
+add_subdirectory(${SOURCE_DIRECTORY})
 
-#target_link_libraries(${SERVER_PROGRAM}
-#    "${TARGET}"
-#    Threads::Threads
-#)
-
-#set(CLIENT_PROGRAM_SOURCES
-#    "${SOURCE_DIRECTORY}/${CLIENT_TARGET}.cpp"
-#    "${EXTERNAL_DIRECTORY}/json/jsoncpp.cpp"
-#    "${SOURCE_DIRECTORY}/main/cli_client.cpp"
-#)
-#add_executable(${CLIENT_PROGRAM} ${CLIENT_PROGRAM_SOURCES})
-#target_include_directories(${CLIENT_PROGRAM} PRIVATE
-#    "${INCLUDE_DIRECTORY}"
-#    "${EXTERNAL_DIRECTORY}"
-#    "${EXTERNAL_DIRECTORY}/websocketpp"
-#    "${EXTERNAL_DIRECTORY}/websocketpp/common"
-#    "${EXTERNAL_DIRECTORY}/asio"
-#    "${OPENSSL_INCLUDES}"
-#    "/usr/local/opt/openssl/include"
-#)
-#target_link_libraries(${CLIENT_PROGRAM}
-#    Threads::Threads
-#    ${OPENSSL_LIBRARIES}
-#    ${PLATFORM_LIBRARIES}
-#)
-
-#file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/trajectory")
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/trajectory")

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ RUN mkdir /agentsim-dev && \
 	cmake \
 	curl \
 	git \
-  openssl \
+	openssl \
 	libblas-dev \
 	libhdf5-dev \
 	liblapack-dev \
 	python-dev \
 	libssl-dev libcurl4-openssl-dev \
 	libblosc1 \
-  libglew-dev mesa-common-dev freeglut3-dev
+  	libglew-dev mesa-common-dev freeglut3-dev
 
 # copy agent sim project
 COPY . /agentsim-dev/agentsim
@@ -32,7 +32,7 @@ RUN git submodule update --init --recursive
 RUN cd ../build && \
 	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DAUTORUN_UNIT_TESTS=OFF && \
 	make && \
-  openssl dhparam -out /dh.pem 2048 && \
+  	openssl dhparam -out /dh.pem 2048 && \
 	find /agentsim-dev/build | grep -i so$ | xargs -i cp {} /agentsim-dev/lib/
 
 ### Run image ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ RUN mkdir /agentsim-dev && \
 	cmake \
 	curl \
 	git \
-    	openssl \
+  openssl \
 	libblas-dev \
 	libhdf5-dev \
 	liblapack-dev \
 	python-dev \
 	libssl-dev libcurl4-openssl-dev \
 	libblosc1 \
-    	libglew-dev mesa-common-dev freeglut3-dev
+  libglew-dev mesa-common-dev freeglut3-dev
 
 # copy agent sim project
 COPY . /agentsim-dev/agentsim
@@ -32,7 +32,7 @@ RUN git submodule update --init --recursive
 RUN cd ../build && \
 	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DAUTORUN_UNIT_TESTS=OFF && \
 	make && \
-    	openssl dhparam -out /dh.pem 2048 && \
+  openssl dhparam -out /dh.pem 2048 && \
 	find /agentsim-dev/build | grep -i so$ | xargs -i cp {} /agentsim-dev/lib/
 
 ### Run image ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ RUN mkdir /agentsim-dev && \
 	cmake \
 	curl \
 	git \
-    openssl \
+    	openssl \
 	libblas-dev \
 	libhdf5-dev \
 	liblapack-dev \
 	python-dev \
 	libssl-dev libcurl4-openssl-dev \
 	libblosc1 \
-    libglew-dev mesa-common-dev freeglut3-dev
+    	libglew-dev mesa-common-dev freeglut3-dev
 
 # copy agent sim project
 COPY . /agentsim-dev/agentsim
@@ -30,9 +30,9 @@ RUN git submodule update --init --recursive
 
 # build agentsim project
 RUN cd ../build && \
-	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release && \
+	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DAUTORUN_UNIT_TESTS=OFF && \
 	make && \
-    openssl dhparam -out /dh.pem 2048 && \
+    	openssl dhparam -out /dh.pem 2048 && \
 	find /agentsim-dev/build | grep -i so$ | xargs -i cp {} /agentsim-dev/lib/
 
 ### Run image ###

--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -1,10 +1,10 @@
 # GOOGLE TEST DEPENDENCY
-#add_subdirectory(gtest)
+add_subdirectory(gtest)
 
 # READDY DEPENDENCY
-#set(READDY_BUILD_PYTHON_WRAPPER OFF CACHE BOOL "don't build ReaDDy's python wrapper")
-#set(READDY_CREATE_TEST_TARGET OFF CACHE BOOL "don't build Readdy test target")
-#add_subdirectory(readdy)
+set(READDY_BUILD_PYTHON_WRAPPER OFF CACHE BOOL "don't build ReaDDy's python wrapper")
+set(READDY_CREATE_TEST_TARGET OFF CACHE BOOL "don't build Readdy test target")
+add_subdirectory(readdy)
 
 # AWS SDK CPP DEPENDENCY
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -20,17 +20,12 @@ endif()
 
 
 # CYTOSIM DEPENDENCY
-#set(BUILD_SIM_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Sim executable" FORCE)
-#set(BUILD_PLAY_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Play executable" FORCE)
-#set(BUILD_CYTOSIM_TESTS OFF CACHE BOOL "don't build Cytosim Tests" FORCE)
-#set(BUILD_CYTOSIM_TOOLS OFF CACHE BOOL "don't build Cytosim Tools" FORCE)
+set(BUILD_SIM_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Sim executable" FORCE)
+set(BUILD_PLAY_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Play executable" FORCE)
+set(BUILD_CYTOSIM_TESTS OFF CACHE BOOL "don't build Cytosim Tests" FORCE)
+set(BUILD_CYTOSIM_TOOLS OFF CACHE BOOL "don't build Cytosim Tools" FORCE)
 
-#if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-#    add_definitions("-mno-avx -mno-avx2")
-#endif()
-#add_subdirectory(cytosim)
-
-#    "${CYTOSIM_LIBRARIES}"
-set(CYTOSIM_LIBRARIES
-    PARENT_SCOPE
-)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_definitions("-mno-avx -mno-avx2")
+endif()
+add_subdirectory(cytosim)

--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -1,10 +1,24 @@
+# GOOGLE TEST DEPENDENCY
 add_subdirectory(gtest)
 
+# READDY DEPENDENCY
 set(READDY_BUILD_PYTHON_WRAPPER OFF CACHE BOOL "don't build ReaDDy's python wrapper")
 set(READDY_CREATE_TEST_TARGET OFF CACHE BOOL "don't build Readdy test target")
 add_subdirectory(readdy)
-add_subdirectory(aws-sdk-cpp)
 
+# AWS SDK CPP DEPENDENCY
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options("-Wno-stringop-truncation")
+    add_compile_options("-Wno-nonnull")
+endif()
+add_subdirectory(aws-sdk-cpp)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(aws-cpp-sdk-core PUBLIC "-Wno-nonnull")
+    target_compile_options(aws-cpp-sdk-core PUBLIC "-Wno-uninitialized")
+endif()
+
+
+# CYTOSIM DEPENDENCY
 set(BUILD_SIM_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Sim executable" FORCE)
 set(BUILD_PLAY_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Play executable" FORCE)
 set(BUILD_CYTOSIM_TESTS OFF CACHE BOOL "don't build Cytosim Tests" FORCE)

--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -1,10 +1,10 @@
 # GOOGLE TEST DEPENDENCY
-add_subdirectory(gtest)
+#add_subdirectory(gtest)
 
 # READDY DEPENDENCY
-set(READDY_BUILD_PYTHON_WRAPPER OFF CACHE BOOL "don't build ReaDDy's python wrapper")
-set(READDY_CREATE_TEST_TARGET OFF CACHE BOOL "don't build Readdy test target")
-add_subdirectory(readdy)
+#set(READDY_BUILD_PYTHON_WRAPPER OFF CACHE BOOL "don't build ReaDDy's python wrapper")
+#set(READDY_CREATE_TEST_TARGET OFF CACHE BOOL "don't build Readdy test target")
+#add_subdirectory(readdy)
 
 # AWS SDK CPP DEPENDENCY
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -15,21 +15,22 @@ add_subdirectory(aws-sdk-cpp)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     target_compile_options(aws-cpp-sdk-core PUBLIC "-Wno-nonnull")
     target_compile_options(aws-cpp-sdk-core PUBLIC "-Wno-uninitialized")
+    target_compile_options(aws-cpp-sdk-core PUBLIC "-Wno-stringop-overflow")
 endif()
 
 
 # CYTOSIM DEPENDENCY
-set(BUILD_SIM_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Sim executable" FORCE)
-set(BUILD_PLAY_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Play executable" FORCE)
-set(BUILD_CYTOSIM_TESTS OFF CACHE BOOL "don't build Cytosim Tests" FORCE)
-set(BUILD_CYTOSIM_TOOLS OFF CACHE BOOL "don't build Cytosim Tools" FORCE)
+#set(BUILD_SIM_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Sim executable" FORCE)
+#set(BUILD_PLAY_EXECUTABLE OFF CACHE BOOL "don't build Cytosim Play executable" FORCE)
+#set(BUILD_CYTOSIM_TESTS OFF CACHE BOOL "don't build Cytosim Tests" FORCE)
+#set(BUILD_CYTOSIM_TOOLS OFF CACHE BOOL "don't build Cytosim Tools" FORCE)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_definitions("-mno-avx -mno-avx2")
-endif()
-add_subdirectory(cytosim)
+#if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#    add_definitions("-mno-avx -mno-avx2")
+#endif()
+#add_subdirectory(cytosim)
 
+#    "${CYTOSIM_LIBRARIES}"
 set(CYTOSIM_LIBRARIES
-    "${CYTOSIM_LIBRARIES}"
     PARENT_SCOPE
 )

--- a/local_build.sh
+++ b/local_build.sh
@@ -4,7 +4,7 @@ echo $sourceDir
 
 if [[ -n "$sourceDir" ]]; then
   export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  cmake $sourceDir -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+  cmake $sourceDir -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DAUTORUN_UNIT_TESTS=OFF
   make
   mkcert -install
   mkcert localhost

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,58 @@
+SET(CMAKE_EXE_LINKER_FLAGS
+"${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath /usr/local/lib -Wl,-rpath /usr/lib")
+
+link_directories(
+  "/usr/local/opt/openssl/lib"
+)
+
+#set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(HDF5 COMPONENTS HL REQUIRED)
+
+add_executable(${SERVER_PROGRAM} ${SOURCE_DIRECTORY}/${SERVER_TARGET}.cpp)
+
+if(UNIX AND APPLE)
+  set(PLATFORM_LIBRARIES
+    "crypto"
+  )
+endif()
+
+target_include_directories(${SERVER_PROGRAM} PUBLIC
+"${INCLUDE_DIRECTORY}"
+"${EXTERNAL_DIRECTORY}"
+"${EXTERNAL_DIRECTORY}/websocketpp"
+"${EXTERNAL_DIRECTORY}/websocketpp/common"
+"${EXTERNAL_DIRECTORY}/asio"
+"/usr/local/opt/openssl/include"
+)
+
+target_link_libraries(${SERVER_PROGRAM}
+    "${TARGET}"
+    Threads::Threads
+)
+
+set(CLIENT_PROGRAM_SOURCES
+    "${SOURCE_DIRECTORY}/${CLIENT_TARGET}.cpp"
+    "${EXTERNAL_DIRECTORY}/json/jsoncpp.cpp"
+    "${SOURCE_DIRECTORY}/main/cli_client.cpp"
+)
+add_executable(${CLIENT_PROGRAM} ${CLIENT_PROGRAM_SOURCES})
+target_include_directories(${CLIENT_PROGRAM} PRIVATE
+    "${INCLUDE_DIRECTORY}"
+    "${EXTERNAL_DIRECTORY}"
+    "${EXTERNAL_DIRECTORY}/websocketpp"
+    "${EXTERNAL_DIRECTORY}/websocketpp/common"
+    "${EXTERNAL_DIRECTORY}/asio"
+    "${OPENSSL_INCLUDES}"
+    "/usr/local/opt/openssl/include"
+)
+target_link_libraries(${CLIENT_PROGRAM}
+    Threads::Threads
+    ${OPENSSL_LIBRARIES}
+    ${PLATFORM_LIBRARIES}
+)
+
 add_subdirectory("main")
 add_subdirectory("test")
+

--- a/src/main/cmake/cytosimpkg.cmake
+++ b/src/main/cmake/cytosimpkg.cmake
@@ -4,7 +4,7 @@ add_library("cytosimPKG" STATIC
     "cytosimpkg.cpp"
 )
 
-target_compile_definitions("cytosimPKG" PRIVATE 
+target_compile_definitions("cytosimPKG" PRIVATE
 -DDIM=${DIMENSION}
 )
 
@@ -30,6 +30,8 @@ set(CYTOSIM_PKG_INCLUDES
   CACHE STRING "The include directories needed by the Cytosim simulation package"
 )
 
+message("Cytosim packages ${CYTOSIM_LIBRARIES}")
+
 target_include_directories("cytosimPKG" PRIVATE
     "${CYTOSIM_PKG_INCLUDES}"
     "${INCLUDE_DIRECTORY}"
@@ -37,7 +39,11 @@ target_include_directories("cytosimPKG" PRIVATE
 )
 
 target_link_libraries("cytosimPKG" PRIVATE
-    "${CYTOSIM_LIBRARIES}"
+    "cytosimD3"
+    "cytospaceD3";
+    "cytomath";
+    "cytobase"
+    Threads::Threads
     "${LAPACK_LIB}"
     "${BLAS_LIB}"
     "loguru"

--- a/src/main/cmake/readdypkg.cmake
+++ b/src/main/cmake/readdypkg.cmake
@@ -4,7 +4,7 @@ add_library("readdyPKG" STATIC
     "readdypkg.cpp"
 )
 
-set(READDY_PKG_INCLUDES
+set(READDY_PKG_INCLUDE_DIRECTORIES
     "${DEPENDENCY_DIRECTORY}/readdy/include/"
     "${DEPENDENCY_DIRECTORY}/readdy/readdy_testing/include"
     "${DEPENDENCY_DIRECTORY}/readdy/libraries/c-blosc/include/"
@@ -13,17 +13,19 @@ set(READDY_PKG_INCLUDES
     "${DEPENDENCY_DIRECTORY}/readdy/libraries/json/include/"
     "${DEPENDENCY_DIRECTORY}/readdy/libraries/pybind11/include/"
     "${DEPENDENCY_DIRECTORY}/readdy/libraries/spdlog/include/"
+    "${DEPENDENCY_DIRECTORY}/readdy/libraries/graph/"
+    "${DEPENDENCY_DIRECTORY}/readdy/libraries/graph/libs/fmt/include"
     "${HDF5_INCLUDE_DIRS}"
     "${HDF5_HL_INCLUDE_DIR}"
     CACHE STRING "The include directories needed by the ReaDDy simulation package"
 )
 
-target_include_directories("readdyPKG" PRIVATE
+target_include_directories("readdyPKG" PUBLIC
     "${READDY_PKG_INCLUDE_DIRECTORIES}"
     "${INCLUDE_DIRECTORY}"
     "${EXTERNAL_DIRECTORY}"
 )
-target_link_libraries("readdyPKG" PRIVATE
+target_link_libraries("readdyPKG" PUBLIC
     "readdy"
     "readdy_model"
     "readdy_kernel_cpu"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -5,7 +5,6 @@ set(EXECUTABLE_OUTPUT_PATH
 )
 
 set(TEST_LIST
-"test_aws_util"
 "test_client_server"
 "test_net_commands"
 "test_sim_time"
@@ -17,10 +16,6 @@ set(TEST_INCLUDES
     "${EXTERNAL_DIRECTORY}/websocketpp"
     "${EXTERNAL_DIRECTORY}/websocketpp/common"
     "${EXTERNAL_DIRECTORY}/asio"
-    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-core/include"
-    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-transfer/include"
-    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-awstransfer/include"
-    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-s3/include"
     "${DEPENDENCY_DIRECTORY}/gtest/googletest/include"
     "${OPENSSL_INCLUDES}"
     "/usr/local/opt/openssl/include"
@@ -39,3 +34,29 @@ foreach(TEST_NAME ${TEST_LIST})
 	target_include_directories(${TEST_NAME} PUBLIC "${TEST_INCLUDES}")
 	target_link_libraries(${TEST_NAME} PUBLIC "${TEST_LIBS}")
 endforeach()
+
+add_executable(test_aws_util "test_aws_util.cpp")
+target_include_directories(test_aws_util PUBLIC
+    "${INCLUDE_DIRECTORY}"
+    "${EXTERNAL_DIRECTORY}"
+    "${EXTERNAL_DIRECTORY}/websocketpp"
+    "${EXTERNAL_DIRECTORY}/websocketpp/common"
+    "${EXTERNAL_DIRECTORY}/asio"
+    "${DEPENDENCY_DIRECTORY}/gtest/googletest/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/crt/aws-crt-cpp/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/crt/aws-crt-cpp/crt/aws-c-common/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/crt/aws-crt-cpp/crt/aws-c-common/verification/cbmc/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/crt/aws-crt-cpp/crt/aws-c-io/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/crt/aws-crt-cpp/crt/aws-c-mqtt/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-core/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-s3/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-awstransfer/include"
+    "${DEPENDENCY_DIRECTORY}/aws-sdk-cpp/aws-cpp-sdk-transfer/include"
+    "${OPENSSL_INCLUDES}"
+    "/usr/local/opt/openssl/include"
+)
+target_link_libraries(test_aws_util PUBLIC
+	"${TARGET}"
+	"gtest_main"
+	"gtest"
+)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TEST_INCLUDES
 
 set(TEST_LIBS
     "${TARGET}"
-    Threads::Threads
+    #Threads::Threads
     "gtest_main"
     "gtest"
     "${CYTOSIM_LIBRARIES}"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,7 +23,6 @@ set(TEST_INCLUDES
 
 set(TEST_LIBS
     "${TARGET}"
-    #Threads::Threads
     "gtest_main"
     "gtest"
     "${CYTOSIM_LIBRARIES}"


### PR DESCRIPTION
**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

This PR: 
-  Updates the aws-cpp-sdk
-  Reorganizes the build config so that fewer of the compilation targets interfere with each other

Resolves:
https://github.com/allen-cell-animated/simularium-engine/issues/15
https://github.com/allen-cell-animated/simularium-engine/issues/16

More details:
GCC 11 added warning for several common memory/compile errors. The way the simularium-engine build was setup, warnings are treated as errors. More generally, the compilation environment reflected the strictest settings from any dependency.

To address this, the compilation environment for the dependencies (simulation engines) and the server have been separated further. There is still overlap, but it is a step in the right direction. Further, the aws-sdk-cpp was updated to receive changes that allowed us more control over the compilation environment  for the sdk.

Autorun tests, in the sdk, were disabled, since there are known issues with some of the newer tests in untested environments (e.g. Docker images)
https://github.com/aws/aws-sdk-cpp/issues/1601 
