### PR TITLE
Update Frame Selection Time to use Epsilon

### DIFF
--- a/src/main/aws_util.cpp
+++ b/src/main/aws_util.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <string>
 
-static const Aws::String kBucketName = "aics-agentviz-data";
+static const Aws::String kBucketName = "aics-simularium-data";
 static const Aws::String kAwsRegion = "us-east-2";
 
 namespace aics {

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -324,10 +324,10 @@ namespace simularium {
                 return tfp.numberOfFrames - 1;
             }
 
-            // Integer division performed to get nearest frames
-            // e.g. 8 ns / 3 ns = use frame 2 (time - 6 ns)
-            int time = simulationTimeNs / tfp.timeStepSize;
-            return time;
+            // Return the nearest frame based on a fixed time-step size
+            //  e.g. timestep = 2, requestedTime = 5.1,
+            //   round(5.1/2) = round(2.55) = frame 3
+            return std::round(simulationTimeNs / tfp.timeStepSize);
         }
 
         if (this->m_SimPkgs.size() > 0 && this->m_SimPkgs[this->m_activeSimPkg]->CanLoadFile(identifier)) {

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -309,7 +309,7 @@ namespace simularium {
             std::size_t numFrames = this->m_cache.GetNumFrames(identifier);
             return std::min(
                 static_cast<std::size_t>(simulationTimeNs),
-                numFrames);
+                numFrames - 1);
         }
 
         auto tfp = this->GetFileProperties(identifier);

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -320,14 +320,19 @@ namespace simularium {
             // If the requested time is past the end,
             //  return the last frame avaliable
             auto totalDuration = tfp.numberOfFrames * tfp.timeStepSize;
-            if (simulationTimeNs >= totalDuration) {
+            float epsilon = 1e-15;
+            if (simulationTimeNs >= totalDuration + epsilon) {
                 return tfp.numberOfFrames - 1;
             }
 
             // Return the nearest frame based on a fixed time-step size
             //  e.g. timestep = 2, requestedTime = 5.1,
             //   round(5.1/2) = round(2.55) = frame 3
-            return std::round(simulationTimeNs / tfp.timeStepSize);
+            std::size_t frameNum = std::round(simulationTimeNs / tfp.timeStepSize);
+            return std::min(
+              frameNum,
+              tfp.numberOfFrames - 1
+            );
         }
 
         if (this->m_SimPkgs.size() > 0 && this->m_SimPkgs[this->m_activeSimPkg]->CanLoadFile(identifier)) {

--- a/src/test/test_sim_time.cpp
+++ b/src/test/test_sim_time.cpp
@@ -65,21 +65,21 @@ namespace simularium {
             frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.5);
             EXPECT_EQ(frameNum, 5);
 
-            // Beginning plus epsilon
+            // Beginning plus epsilon, floating point
             float epsilon = 1e-15;
-            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 0 + epsilon);
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 0. + epsilon);
             EXPECT_EQ(frameNum, 0);
 
-            // Beginning minus epsilon
-            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 0 - epsilon);
+            // Beginning minus epsilon, floating point
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 0. - epsilon);
             EXPECT_EQ(frameNum, 0);
 
-            // End plus epsilon
-            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 99 + epsilon);
+            // End plus epsilon, floating point
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 99. + epsilon);
             EXPECT_EQ(frameNum, 99);
 
-            // End minus epsilon
-            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 99 - epsilon);
+            // End minus epsilon, floating point
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 99. - epsilon);
             EXPECT_EQ(frameNum, 99);
 
             std::remove(simFilePath.c_str());

--- a/src/test/test_sim_time.cpp
+++ b/src/test/test_sim_time.cpp
@@ -57,7 +57,7 @@ namespace simularium {
             frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.6);
             EXPECT_EQ(frameNum, 5);
 
-            // A non integer time request, round up
+            // A non integer time request, round down
             frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.4);
             EXPECT_EQ(frameNum, 4);
 

--- a/src/test/test_sim_time.cpp
+++ b/src/test/test_sim_time.cpp
@@ -53,6 +53,18 @@ namespace simularium {
             frameNum = simulation.GetClosestFrameNumberForTime(simFileName, -1);
             EXPECT_EQ(frameNum, 0);
 
+            // A non integer time request, round up
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.6);
+            EXPECT_EQ(frameNum, 5);
+
+            // A non integer time request, round up
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.4);
+            EXPECT_EQ(frameNum, 4);
+
+            // A non integer time request, round up w/ epsilon
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.5);
+            EXPECT_EQ(frameNum, 5);
+
             std::remove(simFilePath.c_str());
         }
 

--- a/src/test/test_sim_time.cpp
+++ b/src/test/test_sim_time.cpp
@@ -65,6 +65,23 @@ namespace simularium {
             frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 4.5);
             EXPECT_EQ(frameNum, 5);
 
+            // Beginning plus epsilon
+            float epsilon = 1e-15;
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 0 + epsilon);
+            EXPECT_EQ(frameNum, 0);
+
+            // Beginning minus epsilon
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 0 - epsilon);
+            EXPECT_EQ(frameNum, 0);
+
+            // End plus epsilon
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 99 + epsilon);
+            EXPECT_EQ(frameNum, 99);
+
+            // End minus epsilon
+            frameNum = simulation.GetClosestFrameNumberForTime(simFileName, 99 - epsilon);
+            EXPECT_EQ(frameNum, 99);
+
             std::remove(simFilePath.c_str());
         }
 


### PR DESCRIPTION
**Pull request recommendations:**

- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [ ] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

Resolves: https://github.com/allen-cell-animated/simularium-engine/issues/14

Instead of doing integer division select a frame, the round function is now used. 
This will select the nearest frame instead of the lower frame.

e.g. with a time-step of 1,
Previously, requesting time 4.9 returned frame 4
Now, requesting time 4.9 will return frame 5
