### PR TITLE
feature/move-trajinfo-parsing-to-separate-file

### DIFF
--- a/src/main/parse_traj_info.cc
+++ b/src/main/parse_traj_info.cc
@@ -1,0 +1,64 @@
+TrajectoryFileProperties parse_traj_info_v1(Json::Value fprops) {
+  TrajectoryFileProperties tfp;
+
+  const Json::Value typeMapping = fprops["typeMapping"];
+  std::vector<std::string> ids = typeMapping.getMemberNames();
+  for (auto& id : ids) {
+      std::size_t idKey = std::atoi(id.c_str());
+      const Json::Value entry = typeMapping[id];
+      tfp.typeMapping[idKey] = entry["name"].asString();
+  }
+
+  const Json::Value& size = fprops["size"];
+  tfp.boxX = size["x"].asFloat();
+  tfp.boxY = size["y"].asFloat();
+  tfp.boxZ = size["z"].asFloat();
+
+  tfp.fileName = fprops["fileName"].asString();
+  tfp.numberOfFrames = fprops["totalSteps"].asInt();
+  tfp.timeStepSize = fprops["timeStepSize"].asFloat();
+  tfp.spatialUnitFactorMeters = fprops["spatialUnitFactorMeters"].asFloat();
+  // Optional Fields
+  const Json::Value& cameraDefault = fprops["cameraDefault"];
+  if (cameraDefault != Json::nullValue) {
+      const Json::Value& cpos = cameraDefault["position"];
+      if (cpos != Json::nullValue) {
+          tfp.cameraDefault.position[0] = cpos["x"].asFloat();
+          tfp.cameraDefault.position[1] = cpos["y"].asFloat();
+          tfp.cameraDefault.position[2] = cpos["z"].asFloat();
+      }
+      const Json::Value& lookAt = cameraDefault["lookAtPoint"];
+      if (lookAt != Json::nullValue) {
+          tfp.cameraDefault.lookAtPoint[0] = lookAt["x"].asFloat();
+          tfp.cameraDefault.lookAtPoint[1] = lookAt["y"].asFloat();
+          tfp.cameraDefault.lookAtPoint[2] = lookAt["z"].asFloat();
+      }
+      const Json::Value& upVec = cameraDefault["upVector"];
+      if (upVec != Json::nullValue) {
+          tfp.cameraDefault.upVector[0] = upVec["x"].asFloat();
+          tfp.cameraDefault.upVector[1] = upVec["y"].asFloat();
+          tfp.cameraDefault.upVector[2] = upVec["z"].asFloat();
+      }
+
+      if (cameraDefault.isMember("fovDegrees")) {
+          tfp.cameraDefault.fovDegrees = cameraDefault["fovDegrees"].asFloat();
+      }
+
+      return tfp;
+    }
+}
+
+TrajectoryFileProperties parse_trajectory_info_json(Json::Value trajInfo) {
+    int version = trajInfo["version"].asInt();
+    switch(version) {
+      case 1: {
+        return parse_traj_info_v1(trajInfo);
+        break;
+      }
+      default: {
+        LOG_F(WARNING, "Unrecognized version %i, defaulting to version 1", version);
+      }
+    }
+
+    return parse_traj_info_v1(trajInfo);
+}

--- a/src/main/simulation_cache.cpp
+++ b/src/main/simulation_cache.cpp
@@ -27,6 +27,8 @@ inline bool FileExists(const std::string& name)
 namespace aics {
 namespace simularium {
 
+#include "parse_traj_info.cc"
+
     inline void CreateCacheFolder()
     {
         std::string cmd = "mkdir -p " + config::GetCacheFolder();
@@ -371,54 +373,7 @@ namespace simularium {
 
     void SimulationCache::ParseFileProperties(Json::Value& fprops, std::string identifier)
     {
-        TrajectoryFileProperties tfp;
-
-        // Required Fields
-        const Json::Value typeMapping = fprops["typeMapping"];
-        std::vector<std::string> ids = typeMapping.getMemberNames();
-        for (auto& id : ids) {
-            std::size_t idKey = std::atoi(id.c_str());
-            const Json::Value entry = typeMapping[id];
-            tfp.typeMapping[idKey] = entry["name"].asString();
-        }
-
-        const Json::Value& size = fprops["size"];
-        tfp.boxX = size["x"].asFloat();
-        tfp.boxY = size["y"].asFloat();
-        tfp.boxZ = size["z"].asFloat();
-
-        tfp.fileName = fprops["fileName"].asString();
-        tfp.numberOfFrames = fprops["totalSteps"].asInt();
-        tfp.timeStepSize = fprops["timeStepSize"].asFloat();
-        tfp.spatialUnitFactorMeters = fprops["spatialUnitFactorMeters"].asFloat();
-        // Optional Fields
-        const Json::Value& cameraDefault = fprops["cameraDefault"];
-        if (cameraDefault != Json::nullValue) {
-            const Json::Value& cpos = cameraDefault["position"];
-            if (cpos != Json::nullValue) {
-                tfp.cameraDefault.position[0] = cpos["x"].asFloat();
-                tfp.cameraDefault.position[1] = cpos["y"].asFloat();
-                tfp.cameraDefault.position[2] = cpos["z"].asFloat();
-            }
-            const Json::Value& lookAt = cameraDefault["lookAtPoint"];
-            if (lookAt != Json::nullValue) {
-                tfp.cameraDefault.lookAtPoint[0] = lookAt["x"].asFloat();
-                tfp.cameraDefault.lookAtPoint[1] = lookAt["y"].asFloat();
-                tfp.cameraDefault.lookAtPoint[2] = lookAt["z"].asFloat();
-            }
-            const Json::Value& upVec = cameraDefault["upVector"];
-            if (upVec != Json::nullValue) {
-                tfp.cameraDefault.upVector[0] = upVec["x"].asFloat();
-                tfp.cameraDefault.upVector[1] = upVec["y"].asFloat();
-                tfp.cameraDefault.upVector[2] = upVec["z"].asFloat();
-            }
-
-            if (cameraDefault.isMember("fovDegrees")) {
-                tfp.cameraDefault.fovDegrees = cameraDefault["fovDegrees"].asFloat();
-            }
-        }
-
-        // Store the result
+        TrajectoryFileProperties tfp = parse_trajectory_info_json(fprops);
         this->m_fileProps[identifier] = tfp;
     }
 


### PR DESCRIPTION
**Pull request recommendations:**

- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [ ] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

A follow up from this morning - moves the trajectory-info parsing out of the simulation_cache object as a demonstration. The current TrajectoryFileProperties object corresponds to 'version 1' of this object.

The next steps will be to...

- implement v2 & v3 parsing in the same file
- update the TrajectoryFileProperties object to reflect the v3 (latest) object
- replace the broadcast formatting [here](https://github.com/allen-cell-animated/simularium-engine/blob/main/src/main/connection_manager.cpp#L934) w/ v3 (latest)
